### PR TITLE
Avoid implicit block magic in Mocoso#expect.

### DIFF
--- a/lib/mocoso.rb
+++ b/lib/mocoso.rb
@@ -106,14 +106,14 @@ module Mocoso
   #     # => true
   #   end
   #
-  def expect(object, method, options)
+  def expect(object, method, options, &block)
     expectation = ->(*params) {
       with = options.fetch(:with, [])
       raise ExpectationError, "Expected #{with}, got #{params}" if params != with
       options.fetch(:return)
     }
 
-    stub(object, method, expectation, &proc)
+    stub(object, method, expectation, &block)
   end
 
   # Raised by #expect when a expectation is not fulfilled.


### PR DESCRIPTION
Normally if one tries to create a `Proc` via `Proc.new` or `Kernel#proc` without passing a block to the method, one gets an `ArgumentError: tried to create Proc object without a block`.  However, if this occurs within a method that was passed a block but did not "capture" it into a argument, it gets magically passed to the Proc initializer.

Incidentally, this isn't implemented on Rubinius (and I doubt such a magic feature is a high priority).
https://github.com/rubinius/rubinius/issues/3202

JRuby has this feature, but Charles Nutter has expressed a desire to disable it, as well as claiming that it only works on MRI by accident due to implementation details, with the MRI team just deciding to call the accident a feature, I suppose.
http://jira.codehaus.org/browse/JRUBY-5420

This library is often chosen for its simplicity, and I'd argue that in that spirit it would be best to avoid such magic, especially when there is nothing to gain compared to simply capturing the block as an argument.  To that end, this PR makes `Mocoso#expect` just pass the block argument on to the next method in the boring, everyday way.

EDIT: Just found an additional reference: there has been talk of deprecating this in MRI 2.2
https://bugs.ruby-lang.org/issues/10499
